### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/backend/src/controllers/nftController.ts
+++ b/backend/src/controllers/nftController.ts
@@ -6,8 +6,12 @@ import { uploadToIPFS } from '../utils/ipfs'
 
 export const generateAndMintNFT = async (req: Request, res: Response) => {
   const { prompt, walletAddress, length } = req.body
-  if (!prompt || !walletAddress || !length) {
-    return res.status(400).json({ error: 'Missing required fields' })
+  if (
+    typeof prompt !== 'string' || 
+    typeof walletAddress !== 'string' || 
+    typeof length !== 'number'
+  ) {
+    return res.status(400).json({ error: 'Invalid input types. "prompt" and "walletAddress" must be strings, and "length" must be a number.' })
   }
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/mintmuseily/security/code-scanning/4](https://github.com/940smiley/mintmuseily/security/code-scanning/4)

To fix the issue, we need to validate the types of `prompt`, `walletAddress`, and `length` to ensure they are strings (or numbers, as appropriate) before using them. This can be done by adding explicit type checks for these parameters. If any parameter fails the type check, the function should return a `400 Bad Request` response with an appropriate error message.

The changes will be made in the `generateAndMintNFT` function in the file `backend/src/controllers/nftController.ts`. Specifically:
1. Add type checks for `prompt`, `walletAddress`, and `length` to ensure they are of the expected types.
2. Return an error response if any parameter fails the type check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
