### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/backend/src/services/barkservice.ts
+++ b/backend/src/services/barkservice.ts
@@ -1,9 +1,8 @@
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 
 export const generateAudio = (text: string, outputPath: string): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const command = `python3 ./scripts/generate_audio.py "${text}" "${outputPath}"`
-    exec(command, (err, stdout, stderr) => {
+    execFile('python3', ['./scripts/generate_audio.py', text, outputPath], (err, stdout, stderr) => {
       if (err) {
         console.error(stderr)
         return reject(stderr)


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/mintmuseily/security/code-scanning/3](https://github.com/940smiley/mintmuseily/security/code-scanning/3)

To fix the issue, we should avoid using `exec` and instead use `execFile` or `spawn`, which allow passing arguments as an array. These APIs do not invoke a shell, making them safer against command injection. Specifically, we will replace the `exec` call with `execFile`, passing the script name and its arguments as separate array elements. This ensures that user input is treated as data rather than executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
