### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,8 @@
     "mongoose": "^6.13.8",
     "multer": "^1.4.5-lts.2",
     "nft.storage": "^7.2.0",
-    "rex": "^1.0.0"
+    "rex": "^1.0.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",

--- a/backend/src/routes/nft.ts
+++ b/backend/src/routes/nft.ts
@@ -1,8 +1,16 @@
 import { Router } from 'express'
 import { generateAndMintNFT } from '../controllers/nftController'
+import rateLimit from 'express-rate-limit'
 
 const router = Router()
 
-router.post('/mint', generateAndMintNFT)
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const mintRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.',
+})
+
+router.post('/mint', mintRateLimiter, generateAndMintNFT)
 
 export default router


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/mintmuseily/security/code-scanning/1](https://github.com/940smiley/mintmuseily/security/code-scanning/1)

To address the issue, we will add rate limiting to the `/mint` route using the `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the endpoint within a specified time window. Specifically:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `/mint` route.

This fix ensures that the endpoint is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
