### PR TITLE
Potential fix for code scanning alert no. 5: Type confusion through parameter tampering

### DIFF
--- a/backend/src/controllers/nftController.ts
+++ b/backend/src/controllers/nftController.ts
@@ -7,8 +7,8 @@ import { uploadToIPFS } from '../utils/ipfs'
 export const generateAndMintNFT = async (req: Request, res: Response) => {
   const { prompt, walletAddress, length } = req.body
   if (
-    typeof prompt !== 'string' || 
-    typeof walletAddress !== 'string' || 
+    typeof prompt !== 'string' || Array.isArray(prompt) || 
+    typeof walletAddress !== 'string' || Array.isArray(walletAddress) || 
     typeof length !== 'number'
   ) {
     return res.status(400).json({ error: 'Invalid input types. "prompt" and "walletAddress" must be strings, and "length" must be a number.' })


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/mintmuseily/security/code-scanning/5](https://github.com/940smiley/mintmuseily/security/code-scanning/5)

To fix the issue, we need to ensure that the `prompt` and `walletAddress` parameters are strictly validated as strings and that `length` is validated as a number. Specifically:
1. Add a check to ensure that `prompt` and `walletAddress` are not arrays by verifying their runtime type using `Array.isArray`.
2. Update the existing type checks to include this additional validation.
3. If any of the parameters fail validation, return a `400 Bad Request` response with an appropriate error message.

This fix ensures that the parameters are of the expected types and prevents type confusion attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
